### PR TITLE
Modernize scripts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Install script for Simplified ScreenCapper Pro
 

--- a/master.sh
+++ b/master.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Base directory
 BASE_DIR="./"
@@ -66,6 +67,6 @@ run_shell_task "Transfer to Quality Check" "${SCRIPT_DIR}/transfer-face-quali.sh
 run_python_task "Quality Check" "${SCRIPT_DIR}/quality_check.py" "${SCRIPT_DIR}/task_running_QualityCheck"
 
 # Task 6: Transfer (QUALI -> output)
-run_shell_task "Transfer to Output and Cleanup" "${SCRIPT_DIR}/transfer-output.sh" "${SCRIPT_DIR}/task_running_TransferQualiToOutput"
+run_shell_task "Transfer to Output and Cleanup" "${SCRIPT_DIR}/transfer-output.sh" "${SCRIPT_DIR}/task_running_TransferOutput"
 
 echo "All tasks completed. Master script finished."

--- a/transfer-cap-face.sh
+++ b/transfer-cap-face.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Folder structure relative to the base directory
 BASE_DIR="$(dirname "$(dirname "$(realpath "$0")")")"

--- a/transfer-face-quali.sh
+++ b/transfer-face-quali.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Folder structure relative to the base directory
 BASE_DIR="$(dirname "$(dirname "$(realpath "$0")")")"

--- a/transfer-output.sh
+++ b/transfer-output.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
+set -e
 
 # Folder structure relative to the base directory
 BASE_DIR="$(dirname "$(dirname "$(realpath "$0")")")"
 SOURCE_DIR="${BASE_DIR}/6.quali_output"
-FINAL_OUTPUT_DIR="${BASE_DIR}/7.output"
+FINAL_OUTPUT_DIR="${BASE_DIR}/output"
 ARCHIVE_DIR="${BASE_DIR}/archiv/3.quali"
-TASK_FILE="${BASE_DIR}/00.scripts/task_running_TransferQualiToOutput"
+TASK_FILE="${BASE_DIR}/00.scripts/task_running_TransferOutput"
 
 echo "Starting transfer script: QUALI -> OUTPUT"
 


### PR DESCRIPTION
## Summary
- refresh python utilities to use `pathlib` and `argparse`
- add task consistency for transfer to output step
- enforce safer shell scripting with `set -e`
- fix stray text in scripts and unify output folder

## Testing
- `python3 -m py_compile frame_export.py face_recognition.py quality_check.py`
- `bash -n master.sh transfer-cap-face.sh transfer-face-quali.sh transfer-output.sh install.sh`


------
https://chatgpt.com/codex/tasks/task_e_6849880807cc8333b3ec440419838745