### PR TITLE
Add queue pruning script and improve task file handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Simplified ScreenCapper Pro is a modular and automated pipeline for processing v
 - **Cleanup**: Clears all process folders (`1.cap_input` to `6.quali_output`).
 - **Task Indicator**: `task_running_TransferOutput`.
 
+### 7. Queue Pruning (`pruning.sh`)
+- **Purpose**: Manually clear all queue folders.
+- **Safety**: Asks for confirmation before deleting files.
+
 ---
 
 ## Folder Structure
@@ -68,6 +72,7 @@ Simplified ScreenCapper Pro is a modular and automated pipeline for processing v
 │   ├── transfer-cap-face.sh   # Transfer: CAP -> FACE
 │   ├── transfer-face-quali.sh # Transfer: FACE -> QUALI
 │   ├── transfer-output.sh     # Transfer: QUALI -> OUTPUT
+│   ├── pruning.sh            # Clear all queue folders
 │   └── model/                 # YOLOv8 model file
 │       └── AniRef40000-l-epoch50.pt
 ├── 1.cap_input/               # Input folder for raw videos

--- a/frame_export.py
+++ b/frame_export.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import cv2
 from tqdm import tqdm
+import logging
 
 
 def extract_frames(input_dir: Path, output_dir: Path) -> None:
@@ -16,7 +17,7 @@ def extract_frames(input_dir: Path, output_dir: Path) -> None:
 
     video_files = [f for f in input_dir.iterdir() if f.suffix.lower() in {".mp4", ".avi", ".mkv"}]
     if not video_files:
-        print("No videos found in the input folder.")
+        logging.info("No videos found in the input folder.")
         return
 
     for video_file in tqdm(video_files, desc="Overall Progress", unit="video"):
@@ -35,7 +36,7 @@ def extract_frames(input_dir: Path, output_dir: Path) -> None:
                 frame_count += 1
                 pbar.update(1)
         cap.release()
-        print(f"Frames extracted: {frame_count} frames saved to {output_dir}")
+        logging.info("Frames extracted: %d frames saved to %s", frame_count, output_dir)
 
 
 def main() -> None:
@@ -47,9 +48,16 @@ def main() -> None:
     input_dir = base_dir / "1.cap_input"
     output_dir = base_dir / "2.cap_output"
 
-    print("Starting frame extraction for anime videos...")
-    extract_frames(input_dir, output_dir)
-    print("All videos have been processed.")
+    task_file = base_dir / "00.scripts" / "task_running_Cap01"
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    logging.info("Starting frame extraction for anime videos...")
+    task_file.touch()
+    try:
+        extract_frames(input_dir, output_dir)
+    finally:
+        task_file.unlink(missing_ok=True)
+    logging.info("All videos have been processed.")
 
 
 if __name__ == "__main__":

--- a/pruning.sh
+++ b/pruning.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+# Folder structure relative to the base directory
+BASE_DIR="$(dirname "$(dirname "$(realpath "$0")")")"
+
+QUEUES=(
+    "${BASE_DIR}/1.cap_input"
+    "${BASE_DIR}/2.cap_output"
+    "${BASE_DIR}/3.face_input"
+    "${BASE_DIR}/4.face_output"
+    "${BASE_DIR}/5.quali_input"
+    "${BASE_DIR}/6.quali_output"
+)
+
+read -r -p "This will remove all files in the queue folders. Continue? [y/N] " CONFIRM
+if [[ ! $CONFIRM =~ ^[Yy]$ ]]; then
+    echo "Pruning cancelled."
+    exit 0
+fi
+
+for DIR in "${QUEUES[@]}"; do
+    echo "Clearing folder: $DIR"
+    rm -rf "$DIR/"*
+    mkdir -p "$DIR"
+done
+
+echo "All queues have been pruned."

--- a/quality_check.py
+++ b/quality_check.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import cv2
 from skimage.metrics import structural_similarity as ssim
+import logging
 
 
 def calculate_ssim(image1, image2) -> float:
@@ -44,7 +45,7 @@ def deduplicate_images(input_folder: Path, output_folder: Path, similarity_thres
                 kept_images.append(image_path1)
                 output_path = output_folder / image_path1.name
                 cv2.imwrite(str(output_path), image1)
-                print(f"Saved: {output_path}")
+                logging.info("Saved: %s", output_path)
 
 
 def main() -> None:
@@ -57,10 +58,16 @@ def main() -> None:
     base_dir = Path(args.base_dir)
     input_dir = base_dir / "5.quali_input"
     output_dir = base_dir / "6.quali_output"
+    task_file = base_dir / "00.scripts" / "task_running_QualityCheck"
 
-    print("Starting Quality Control...")
-    deduplicate_images(input_dir, output_dir, args.ssim, args.edge)
-    print("Quality Control completed. Results saved in the output folder.")
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    logging.info("Starting Quality Control...")
+    task_file.touch()
+    try:
+        deduplicate_images(input_dir, output_dir, args.ssim, args.edge)
+    finally:
+        task_file.unlink(missing_ok=True)
+    logging.info("Quality Control completed. Results saved in the output folder.")
 
 
 if __name__ == "__main__":

--- a/transfer-cap-face.sh
+++ b/transfer-cap-face.sh
@@ -12,6 +12,7 @@ echo "Starting transfer script: CAP -> FACE"
 
 # Create task indicator
 touch "$TASK_FILE"
+trap 'rm -f "$TASK_FILE"' EXIT
 
 # Ensure the archive folder exists
 mkdir -p "$ARCHIVE_DIR"
@@ -22,9 +23,12 @@ ZIP_NAME="${ARCHIVE_DIR}/cap_output_${TIMESTAMP}.zip"
 echo "Creating ZIP archive: $ZIP_NAME"
 zip -r "$ZIP_NAME" "$SOURCE_DIR" >/dev/null
 
-# Move files to the target directory
-mv "$SOURCE_DIR/"* "$TARGET_DIR/"
+shopt -s nullglob
+files=("$SOURCE_DIR"/*)
+if [ ${#files[@]} -gt 0 ]; then
+    mv "${files[@]}" "$TARGET_DIR/"
+else
+    echo "No files to move."
+fi
+shopt -u nullglob
 echo "Transfer completed: CAP -> FACE"
-
-# Remove task indicator
-rm "$TASK_FILE"

--- a/transfer-face-quali.sh
+++ b/transfer-face-quali.sh
@@ -12,6 +12,7 @@ echo "Starting transfer script: FACE -> QUALI"
 
 # Create task indicator
 touch "$TASK_FILE"
+trap 'rm -f "$TASK_FILE"' EXIT
 
 # Ensure the archive folder exists
 mkdir -p "$ARCHIVE_DIR"
@@ -23,8 +24,12 @@ echo "Creating ZIP archive: $ZIP_NAME"
 zip -r "$ZIP_NAME" "$SOURCE_DIR" >/dev/null
 
 # Move files to the target directory
-mv "$SOURCE_DIR/"* "$TARGET_DIR/"
+shopt -s nullglob
+files=("$SOURCE_DIR"/*)
+if [ ${#files[@]} -gt 0 ]; then
+    mv "${files[@]}" "$TARGET_DIR/"
+else
+    echo "No files to move."
+fi
+shopt -u nullglob
 echo "Transfer completed: FACE -> QUALI"
-
-# Remove task indicator
-rm "$TASK_FILE"

--- a/transfer-output.sh
+++ b/transfer-output.sh
@@ -12,6 +12,7 @@ echo "Starting transfer script: QUALI -> OUTPUT"
 
 # Create task indicator
 touch "$TASK_FILE"
+trap 'rm -f "$TASK_FILE"' EXIT
 
 # Ensure the archive folder exists
 mkdir -p "$ARCHIVE_DIR"
@@ -24,7 +25,14 @@ zip -r "$ZIP_NAME" "$SOURCE_DIR" >/dev/null
 
 # Move files to the final output directory
 mkdir -p "$FINAL_OUTPUT_DIR"
-mv "$SOURCE_DIR/"* "$FINAL_OUTPUT_DIR/"
+shopt -s nullglob
+files=("$SOURCE_DIR"/*)
+if [ ${#files[@]} -gt 0 ]; then
+    mv "${files[@]}" "$FINAL_OUTPUT_DIR/"
+else
+    echo "No files to move."
+fi
+shopt -u nullglob
 echo "Transfer completed: QUALI -> OUTPUT"
 
 # Cleaner: Clear all processing folders (except archive)


### PR DESCRIPTION
## Summary
- add new script `pruning.sh` to clear all queue folders with user confirmation
- document pruning step in README and folder structure
- ensure `frame_export.py` and `quality_check.py` create task indicator files and use logging
- improve transfer scripts with safe move logic and automatic task cleanup

## Testing
- `python3 -m py_compile frame_export.py quality_check.py face_recognition.py`
- `shellcheck` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498b4f31cc833399edd81ab69cef49