### PR TITLE
Fix install script to move files and use unix line endings

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,10 @@ Simplified ScreenCapper Pro is a modular and automated pipeline for processing v
 To simplify the setup process, an `install.sh` script is provided. This script will:
 
 1. Create the necessary folder structure.
-2. Install required Python libraries.
-3. Install necessary system packages.
+2. Move all pipeline scripts into the `00.scripts` directory.
+3. Install required Python libraries.
+4. Install necessary system packages.
+5. Set executable permissions for the scripts.
 
 #### Steps
 1. Clone the repository:
@@ -128,10 +130,7 @@ To simplify the setup process, an `install.sh` script is provided. This script w
    - Visit the [AniRef YOLOv8 GitHub Repository](https://github.com/SoulflareRC/AniRef-yolov8).
    - Download the `AniRef40000-l-epoch50.pt` model.
    - Place the model in the `00.scripts/model/` directory.
-5. Make scripts executable:
-   ```bash
-   chmod -R +x <Base Directory>/00.scripts
-   ```
+5. The installation script automatically sets execute permissions for all scripts.
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,7 @@ set -e
 # Define base directory
 read -p "Enter the base directory for installation (default: current directory): " USER_DIR
 BASE_DIR="${USER_DIR:-$(pwd)}"
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 
 # Define folder structure
 FOLDERS=(
@@ -46,6 +47,27 @@ done
 
 echo "Folder structure created."
 
+# Move script files into the new 00.scripts directory
+SCRIPT_FILES=(
+    "master.sh"
+    "frame_export.py"
+    "face_recognition.py"
+    "quality_check.py"
+    "transfer-cap-face.sh"
+    "transfer-face-quali.sh"
+    "transfer-output.sh"
+    "pruning.sh"
+)
+
+echo "Moving scripts to ${BASE_DIR}/00.scripts..."
+for script in "${SCRIPT_FILES[@]}"; do
+    if [ -f "${SCRIPT_DIR}/${script}" ]; then
+        mv "${SCRIPT_DIR}/${script}" "${BASE_DIR}/00.scripts/"
+        echo "Moved: ${script}"
+    fi
+done
+echo "Scripts moved."
+
 # Install system packages
 echo "Installing required system packages..."
 sudo apt update -y
@@ -58,6 +80,9 @@ echo "System packages installed."
 echo "Installing required Python packages..."
 pip install "${REQUIREMENTS[@]}"
 echo "Python packages installed."
+
+# Ensure all scripts are executable
+chmod -R +x "${BASE_DIR}/00.scripts"
 
 # Display completion message
 echo "Installation complete!"


### PR DESCRIPTION
## Summary
- convert `install.sh` to Unix line endings
- move pipeline scripts into `00.scripts` during installation
- set execute permissions in the install script
- document the improved installation process

## Testing
- `bash -n install.sh`
- `bash -n master.sh`
- `python3 -m py_compile frame_export.py face_recognition.py quality_check.py`

------
https://chatgpt.com/codex/tasks/task_e_6849b7fdf29083339ce046951a7163d2