### PR TITLE
Fix mv command for large file counts

### DIFF
--- a/transfer-cap-face.sh
+++ b/transfer-cap-face.sh
@@ -26,7 +26,9 @@ zip -r "$ZIP_NAME" "$SOURCE_DIR" >/dev/null
 shopt -s nullglob
 files=("$SOURCE_DIR"/*)
 if [ ${#files[@]} -gt 0 ]; then
-    mv "${files[@]}" "$TARGET_DIR/"
+    for file in "${files[@]}"; do
+        mv "$file" "$TARGET_DIR/"
+    done
 else
     echo "No files to move."
 fi

--- a/transfer-face-quali.sh
+++ b/transfer-face-quali.sh
@@ -27,7 +27,9 @@ zip -r "$ZIP_NAME" "$SOURCE_DIR" >/dev/null
 shopt -s nullglob
 files=("$SOURCE_DIR"/*)
 if [ ${#files[@]} -gt 0 ]; then
-    mv "${files[@]}" "$TARGET_DIR/"
+    for file in "${files[@]}"; do
+        mv "$file" "$TARGET_DIR/"
+    done
 else
     echo "No files to move."
 fi

--- a/transfer-output.sh
+++ b/transfer-output.sh
@@ -28,7 +28,9 @@ mkdir -p "$FINAL_OUTPUT_DIR"
 shopt -s nullglob
 files=("$SOURCE_DIR"/*)
 if [ ${#files[@]} -gt 0 ]; then
-    mv "${files[@]}" "$FINAL_OUTPUT_DIR/"
+    for file in "${files[@]}"; do
+        mv "$file" "$FINAL_OUTPUT_DIR/"
+    done
 else
     echo "No files to move."
 fi


### PR DESCRIPTION
## Summary
- fix transfer scripts to move files one by one

## Testing
- `bash -n transfer-cap-face.sh`
- `bash -n transfer-face-quali.sh`
- `bash -n transfer-output.sh`


------
https://chatgpt.com/codex/tasks/task_e_6849bf1408a08333b84d995f57e92189