### PR TITLE
Add telemetry dashboard and agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,21 @@ Run the pipeline manually using:
 ### Optional Daemon
 You can optionally set up a **systemd daemon** to automate the pipeline. The daemon will check the `1.cap_input/` folder every 5 minutes and trigger the pipeline if files are detected. Refer to the `import-checker.timer` and `import-checker.service` configuration for details.
 
+## Telemetry Dashboard
+
+Start the dashboard server:
+```bash
+python3 dashboard.py
+```
+
+Agents post metrics using:
+```bash
+python3 telemetry_agent.py --server http://<dashboard-host>:5000/telemetry
+```
+
+The dashboard shows RAM, CPU, connected users and root storage for each agent.
+
+
 ---
 
 ## Planned Features

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Simple dashboard collecting telemetry data."""
+from __future__ import annotations
+
+from flask import Flask, request, render_template_string
+
+app = Flask(__name__)
+
+telemetry_store: dict[str, dict] = {}
+
+
+template = """
+<!doctype html>
+<title>Telemetry Dashboard</title>
+<h1>Telemetry Dashboard</h1>
+<table border="1" cellpadding="5" cellspacing="0">
+  <tr>
+    <th>Agent</th>
+    <th>RAM %</th>
+    <th>CPU %</th>
+    <th>Users</th>
+    <th>Root Usage %</th>
+  </tr>
+  {% for agent, data in telemetry.items() %}
+  <tr>
+    <td>{{ agent }}</td>
+    <td>{{ '%.1f'|format(data.get('ram_percent', 0)) }}</td>
+    <td>{{ '%.1f'|format(data.get('cpu_percent', 0)) }}</td>
+    <td>{{ data.get('users', 0) }}</td>
+    <td>{{ '%.1f'|format(data.get('root_usage_percent', 0)) }}</td>
+  </tr>
+  {% endfor %}
+</table>
+"""
+
+
+@app.post('/telemetry')
+def telemetry() -> str:
+    data = request.get_json(force=True)
+    agent = data.get('agent_id', 'unknown')
+    telemetry_store[agent] = data
+    return 'ok'
+
+
+@app.get('/')
+def index() -> str:
+    return render_template_string(template, telemetry=telemetry_store)
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)
+

--- a/install.sh
+++ b/install.sh
@@ -30,6 +30,9 @@ REQUIREMENTS=(
     "tqdm"
     "ultralytics"
     "scikit-image"
+    "psutil"
+    "flask"
+    "requests"
 )
 
 # Required system packages

--- a/telemetry_agent.py
+++ b/telemetry_agent.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Telemetry agent posting system metrics to a server."""
+from __future__ import annotations
+
+import argparse
+import os
+import time
+
+import psutil
+import requests
+
+
+def collect_metrics() -> dict:
+    """Collect RAM, CPU, user count and root storage usage."""
+    mem = psutil.virtual_memory()
+    cpu = psutil.cpu_percent(interval=1)
+    users = len(psutil.users())
+    disk = psutil.disk_usage('/')
+    return {
+        'ram_percent': mem.percent,
+        'cpu_percent': cpu,
+        'users': users,
+        'root_usage_percent': disk.percent,
+    }
+
+
+def post_metrics(url: str, agent_id: str) -> None:
+    """Collect metrics and POST them to *url* with *agent_id*."""
+    payload = {'agent_id': agent_id}
+    payload.update(collect_metrics())
+    try:
+        requests.post(url, json=payload, timeout=5)
+    except requests.RequestException as exc:
+        print(f"Failed to post telemetry: {exc}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Send telemetry metrics")
+    parser.add_argument('--server', default='http://localhost:5000/telemetry',
+                        help='Telemetry server URL')
+    parser.add_argument('--agent-id', default=os.uname().nodename,
+                        help='Unique agent identifier')
+    parser.add_argument('--interval', type=int, default=60,
+                        help='Seconds between posts')
+    args = parser.parse_args()
+
+    while True:
+        post_metrics(args.server, args.agent_id)
+        time.sleep(args.interval)
+
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
## Summary
- add a telemetry agent that posts CPU, RAM, user count and disk usage to `/telemetry`
- add a simple Flask dashboard server to collect and display metrics
- install new dependencies: `psutil`, `flask`, `requests`
- document telemetry dashboard usage in README

## Testing
- `python3 -m py_compile frame_export.py face_recognition.py quality_check.py telemetry_agent.py dashboard.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684a7e202b10833391777800f02ea437